### PR TITLE
Rename the equal_to() function to compare_to() to avoid name conflict in...

### DIFF
--- a/test/common/testhelper.hpp
+++ b/test/common/testhelper.hpp
@@ -109,7 +109,7 @@ typename AE::value_type mean_square(const boost::numeric::ublas::vector_expressi
 }
 
 template < class M1, class M2 >
-bool equal_to( const boost::numeric::ublas::matrix_expression<M1> & m1,
+bool compare_to( const boost::numeric::ublas::matrix_expression<M1> & m1,
                const boost::numeric::ublas::matrix_expression<M2> & m2,
                double tolerance = 0.0 ) {
     if ((m1().size1() != m2().size1()) ||
@@ -121,7 +121,7 @@ bool equal_to( const boost::numeric::ublas::matrix_expression<M1> & m1,
 }
 
 template < class M1, class M2 >
-bool equal_to( const boost::numeric::ublas::vector_expression<M1> & m1,
+bool compare_to( const boost::numeric::ublas::vector_expression<M1> & m1,
                const boost::numeric::ublas::vector_expression<M2> & m2,
                double tolerance = 0.0 ) {
     if (m1().size() != m2().size()) {

--- a/test/test_assignment.cpp
+++ b/test/test_assignment.cpp
@@ -27,35 +27,35 @@ bool test_vector() {
     V a(3), ra(3);
     a <<=  1, 2, 3;
     ra(0) = 1; ra(1) = 2; ra(2) = 3;
-    pass &= equal_to(a, ra);
+    pass &= compare_to(a, ra);
 
     V b(7), rb(7);
     b<<= a, 10, a;
     rb(0) = 1; rb(1) = 2; rb(2) = 3; rb(3)=10, rb(4)= 1; rb(5)=2; rb(6)=3;
-    pass &= equal_to(b, rb);
+    pass &= compare_to(b, rb);
 
     {
     V c(6), rc(6);
     c <<= 1, move(2), 3 ,4, 5, move(-5), 10, 10;
     rc(0) = 1; rc(1) = 10; rc(2) = 10; rc(3) = 3; rc(4) = 4; rc(5) = 5;
-    pass &= equal_to(c, rc);
+    pass &= compare_to(c, rc);
 
     V d(6), rd(6);
     d <<= 1, move_to(3), 3 ,4, 5, move_to(1), 10, 10;
     rd(0) = 1; rd(1) = 10; rd(2) = 10; rd(3) = 3; rd(4) = 4; rd(5) = 5;
-    pass &= equal_to(d, rd);
+    pass &= compare_to(d, rd);
     }
 
     {
     V c(6), rc(6);
     c <<= 1, move<2>(), 3 ,4, 5, move<-5>(), 10, 10;
     rc(0) = 1; rc(1) = 10; rc(2) = 10; rc(3) = 3; rc(4) = 4; rc(5) = 5;
-    pass &= equal_to(c, rc);
+    pass &= compare_to(c, rc);
 
     V d(6), rd(6);
     d <<= 1, move_to<3>(), 3 ,4, 5, move_to<1>(), 10, 10;
     rd(0) = 1; rd(1) = 10; rd(2) = 10; rd(3) = 3; rd(4) = 4; rd(5) = 5;
-    pass &= equal_to(d, rd);
+    pass &= compare_to(d, rd);
     }
 
 
@@ -65,7 +65,7 @@ bool test_vector() {
     V fa(3); fa<<= 1, 2, 3;
     f <<= fill_policy::index_plus_assign(), fa;
     rf <<= 6,7,8, 5, 5, 5;
-    pass &= equal_to(f, rf);
+    pass &= compare_to(f, rf);
     }
 
     {
@@ -74,7 +74,7 @@ bool test_vector() {
     V fa(3); fa<<= 1, 2, 3;
     f <<= fill_policy::index_minus_assign(), fa;
     rf <<= 4,3,2, 5, 5, 5;
-    pass &= equal_to(f, rf);
+    pass &= compare_to(f, rf);
     }
 
     return pass;
@@ -87,27 +87,27 @@ bool test_vector_sparse_push_back() {
     V a(3), ra(3);
     a <<= fill_policy::sparse_push_back(), 1, 2, 3;
     ra(0) = 1; ra(1) = 2; ra(2) = 3;
-    pass &= equal_to(a, ra);
+    pass &= compare_to(a, ra);
 
     V b(7), rb(7);
     b<<= fill_policy::sparse_push_back(), a, 10, a;
     rb(0) = 1; rb(1) = 2; rb(2) = 3; rb(3)=10, rb(4)= 1; rb(5)=2; rb(6)=3;
-    pass &= equal_to(b, rb);
+    pass &= compare_to(b, rb);
 
     V c(6), rc(6);
     c <<= fill_policy::sparse_push_back(), 1, move(2), 3 ,4, 5; // Move back (i.e. negative is dangerous for push_back)
     rc(0) = 1; rc(1) = 0; rc(2) = 0; rc(3) = 3; rc(4) = 4; rc(5) = 5;
-    pass &= equal_to(c, rc);
+    pass &= compare_to(c, rc);
 
     V d(6), rd(6);
     d <<= fill_policy::sparse_push_back(), 1, move_to(3), 3 ,4, 5; // Move back (i.e. before current index is dangerous for push_back)
     rd(0) = 1; rd(1) = 0; rd(2) = 0; rd(3) = 3; rd(4) = 4; rd(5) = 5;
-    pass &= equal_to(d, rd);
+    pass &= compare_to(d, rd);
 
     V e(6), re(6);
     e <<= fill_policy::sparse_push_back(), 1, move_to(3), 3 ,4, 5, fill_policy::sparse_insert(), move_to(1), 10, 10; // If you want to move back, use this
     re(0) = 1; re(1) = 10; re(2) = 10; re(3) = 3; re(4) = 4; re(5) = 5;
-    pass &= equal_to(e, re);
+    pass &= compare_to(e, re);
 
     return pass;
 }
@@ -120,23 +120,23 @@ bool test_vector_sparse_insert() {
     V a(3), ra(3);
     a <<= fill_policy::sparse_insert(), 1, 2, 3;
     ra(0) = 1; ra(1) = 2; ra(2) = 3;
-    pass &= equal_to(a, ra);
+    pass &= compare_to(a, ra);
 
     V b(7), rb(7);
     b<<= fill_policy::sparse_insert(), a, 10, a;
     rb(0) = 1; rb(1) = 2; rb(2) = 3; rb(3)=10, rb(4)= 1; rb(5)=2; rb(6)=3;
-    pass &= equal_to(b, rb);
+    pass &= compare_to(b, rb);
 
     V c(6), rc(6);
     c <<= fill_policy::sparse_insert(), 1, move(2), 3 ,4, 5, move(-5), 10, 10; // Move back (i.e. negative is dangerous for sparse)
     rc(0) = 1; rc(1) = 10; rc(2) = 10; rc(3) = 3; rc(4) = 4; rc(5) = 5;
-    pass &= equal_to(c, rc);
+    pass &= compare_to(c, rc);
 
 
     V d(6), rd(6);
     d <<= fill_policy::sparse_insert(), 1, move_to(3), 3 ,4, 5, move_to(1), 10, 10; // Move back (i.e.before is dangerous for sparse)
     rd(0) = 1; rd(1) = 10; rd(2) = 10; rd(3) = 3; rd(4) = 4; rd(5) = 5;
-    pass &= equal_to(d, rd);
+    pass &= compare_to(d, rd);
 
 
     return pass;
@@ -152,7 +152,7 @@ bool test_matrix() {
     RA(0,0)= 1; RA(0,1)=2; RA(0,2)=3;
     RA(1,0)= 4; RA(1,1)=5; RA(1,2)=6;
     RA(2,0)= 7; RA(2,1)=8; RA(2,2)=9;
-    pass &= equal_to(A, RA);
+    pass &= compare_to(A, RA);
 
     {
     V B(3,3), RB(3,3);
@@ -160,7 +160,7 @@ bool test_matrix() {
     b<<= 4,5,6;
     B<<= 1, 2, 3, b, 7, project(b, range(1,3));
     RB<<=1, 2, 3, 4, 5, 6, 7, 5, 6; // If the first worked we can now probably use it.
-    pass &= equal_to(B, RB);
+    pass &= compare_to(B, RB);
     }
 
     {
@@ -169,7 +169,7 @@ bool test_matrix() {
     b<<= 4,5,6;
     B<<= move(1,0), b, move_to(0,0), 1, 2, 3, move(1,0), 7, project(b, range(1,3));
     RB<<=1, 2, 3, 4, 5, 6, 7, 5, 6;
-    pass &= equal_to(B, RB);
+    pass &= compare_to(B, RB);
     }
 
     {
@@ -178,7 +178,7 @@ bool test_matrix() {
     b<<= 1, 2, 3, 4, 5, 6, 7, 8, 9;
     B<<=b;
     RB<<=1, 2, 3, 4, 5, 6, 7, 8, 9;
-    pass &= equal_to(B, RB);
+    pass &= compare_to(B, RB);
     }
 
     {
@@ -192,7 +192,7 @@ bool test_matrix() {
             4,5,4,5,
             2,3,2,3,
             4,5,4,5;
-    pass &= equal_to(B, RB);
+    pass &= compare_to(B, RB);
     }
 
     {
@@ -205,7 +205,7 @@ bool test_matrix() {
             4,5,0,0,
             0,0,2,3,
             0,0,4,5;
-    pass &= equal_to(B, RB);
+    pass &= compare_to(B, RB);
     }
 
     {
@@ -218,7 +218,7 @@ bool test_matrix() {
             4,5,0,0,
             0,0,2,3,
             0,0,4,5;
-    pass &= equal_to(B, RB);
+    pass &= compare_to(B, RB);
     }
 
     {
@@ -231,7 +231,7 @@ bool test_matrix() {
             0,2,3,0,
             0,4,5,0,
             0,0,0,0;
-    pass &= equal_to(B, RB);
+    pass &= compare_to(B, RB);
     }
 
     {
@@ -242,7 +242,7 @@ bool test_matrix() {
             1,2,0,0,
             4,5,0,0,
             0,0,0,0;
-    pass &= equal_to(B, RB);
+    pass &= compare_to(B, RB);
     }
 
     {
@@ -253,7 +253,7 @@ bool test_matrix() {
             0,3,5,0,
             0,6,0,0,
             0,0,0,0;
-    pass &= equal_to(B, RB);
+    pass &= compare_to(B, RB);
     }
 
     {
@@ -264,7 +264,7 @@ bool test_matrix() {
             0,3,0,0,
             0,0,0,0,
             4,5,0,0;
-    pass &= equal_to(B, RB);
+    pass &= compare_to(B, RB);
     }
 
     {
@@ -275,7 +275,7 @@ bool test_matrix() {
             0,3,0,0,
             4,5,6,7,
             8,0,0,0;
-    pass &= equal_to(B, RB);
+    pass &= compare_to(B, RB);
     }
 
     {
@@ -286,7 +286,7 @@ bool test_matrix() {
             0,3,0,0,
             4,5,6,7,
             8,9,0,0;
-    pass &= equal_to(B, RB);
+    pass &= compare_to(B, RB);
     }
 
     {
@@ -299,7 +299,7 @@ bool test_matrix() {
             1,2,3,1,
             1,4,5,1,
             1,1,1,1;
-    pass &= equal_to(B, RB);
+    pass &= compare_to(B, RB);
     }
 
     {
@@ -312,7 +312,7 @@ bool test_matrix() {
             5,4,3,5,
             5,2,1,5,
             5,5,5,5;
-    pass &= equal_to(B, RB);
+    pass &= compare_to(B, RB);
     }
 
 
@@ -328,7 +328,7 @@ bool test_matrix_sparse_push_back() {
     RA(0,0)= 1; RA(0,1)=2; RA(0,2)=3;
     RA(1,0)= 4; RA(1,1)=5; RA(1,2)=6;
     RA(2,0)= 7; RA(2,1)=8; RA(2,2)=9;
-    pass &= equal_to(A, RA);
+    pass &= compare_to(A, RA);
 
     {
     V B(3,3), RB(3,3);
@@ -336,7 +336,7 @@ bool test_matrix_sparse_push_back() {
     b<<= 4,5,6;
     B<<=fill_policy::sparse_push_back(), 1, 2, 3, b, 7, project(b, range(1,3));
     RB<<= 1, 2, 3, 4, 5, 6, 7, 5, 6; // If the first worked we can now probably use it.
-    pass &= equal_to(B, RB);
+    pass &= compare_to(B, RB);
     }
 
     {
@@ -345,7 +345,7 @@ bool test_matrix_sparse_push_back() {
     b<<= 4,5,6;
     B<<=fill_policy::sparse_push_back(), move(1,0), b, fill_policy::sparse_insert(), move_to(0,0), 1, 2, 3, move(1,0), 7, project(b, range(1,3));
     RB<<=1, 2, 3, 4, 5, 6, 7, 5, 6;
-    pass &= equal_to(B, RB);
+    pass &= compare_to(B, RB);
     }
 
     {
@@ -354,7 +354,7 @@ bool test_matrix_sparse_push_back() {
     b<<= 1, 2, 3, 4, 5, 6, 7, 8, 9;
     B<<=b;
     RB<<=1, 2, 3, 4, 5, 6, 7, 8, 9;
-    pass &= equal_to(B, RB);
+    pass &= compare_to(B, RB);
     }
 
 
@@ -369,7 +369,7 @@ bool test_matrix_sparse_push_back() {
             4,5,4,5,
             2,3,2,3,
             4,5,4,5;
-    pass &= equal_to(B, RB);
+    pass &= compare_to(B, RB);
     }
 
 
@@ -382,7 +382,7 @@ bool test_matrix_sparse_push_back() {
             4,5,0,0,
             0,0,2,3,
             0,0,4,5;
-    pass &= equal_to(B, RB);
+    pass &= compare_to(B, RB);
     }
 
     {
@@ -394,7 +394,7 @@ bool test_matrix_sparse_push_back() {
             0,2,3,0,
             0,4,5,0,
             0,0,0,0;
-    pass &= equal_to(B, RB);
+    pass &= compare_to(B, RB);
     }
 
     {
@@ -405,7 +405,7 @@ bool test_matrix_sparse_push_back() {
             1,2,0,0,
             4,5,0,0,
             0,0,0,0;
-    pass &= equal_to(B, RB);
+    pass &= compare_to(B, RB);
     }
     // The next will not work with sparse push_back because elements that are prior to the ones already in are attempted to be added
 /*
@@ -417,7 +417,7 @@ bool test_matrix_sparse_push_back() {
             0,3,5,0,
             0,6,0,0,
             0,0,0,0;
-    pass &= equal_to(B, RB);
+    pass &= compare_to(B, RB);
     }
 */
     {
@@ -428,7 +428,7 @@ bool test_matrix_sparse_push_back() {
             0,3,0,0,
             0,0,0,0,
             4,5,0,0;
-    pass &= equal_to(B, RB);
+    pass &= compare_to(B, RB);
     }
 
     {
@@ -439,7 +439,7 @@ bool test_matrix_sparse_push_back() {
             0,3,0,0,
             4,5,6,7,
             8,0,0,0;
-    pass &= equal_to(B, RB);
+    pass &= compare_to(B, RB);
     }
 
     // The next will not work with sparse push_back because elements that are prior to the ones already in are attempted to be added
@@ -452,7 +452,7 @@ bool test_matrix_sparse_push_back() {
             0,3,0,0,
             4,5,6,7,
             8,9,0,0;
-    pass &= equal_to(B, RB);
+    pass &= compare_to(B, RB);
     }
 */
     return pass;
@@ -467,7 +467,7 @@ bool test_matrix_sparse_insert() {
     RA(0,0)= 1; RA(0,1)=2; RA(0,2)=3;
     RA(1,0)= 4; RA(1,1)=5; RA(1,2)=6;
     RA(2,0)= 7; RA(2,1)=8; RA(2,2)=9;
-    pass &= equal_to(A, RA);
+    pass &= compare_to(A, RA);
 
     {
     V B(3,3), RB(3,3);
@@ -475,7 +475,7 @@ bool test_matrix_sparse_insert() {
     b<<= 4,5,6;
     B<<=fill_policy::sparse_insert(), 1, 2, 3, b, 7, project(b, range(1,3));
     RB<<=1, 2, 3, 4, 5, 6, 7, 5, 6; // If the first worked we can now probably use it.
-    pass &= equal_to(B, RB);
+    pass &= compare_to(B, RB);
     }
 
     {
@@ -484,7 +484,7 @@ bool test_matrix_sparse_insert() {
     b<<= 4,5,6;
     B<<=fill_policy::sparse_insert(), move(1,0), b, fill_policy::sparse_insert(), move_to(0,0), 1, 2, 3, move(1,0), 7, project(b, range(1,3));
     RB<<=1, 2, 3, 4, 5, 6, 7, 5, 6;
-    pass &= equal_to(B, RB);
+    pass &= compare_to(B, RB);
     }
 
     {
@@ -493,7 +493,7 @@ bool test_matrix_sparse_insert() {
     b<<= 1, 2, 3, 4, 5, 6, 7, 8, 9;
     B<<=b;
     RB<<=1, 2, 3, 4, 5, 6, 7, 8, 9;
-    pass &= equal_to(B, RB);
+    pass &= compare_to(B, RB);
     }
 
 
@@ -507,7 +507,7 @@ bool test_matrix_sparse_insert() {
             4,5,4,5,
             2,3,2,3,
             4,5,4,5;
-    pass &= equal_to(B, RB);
+    pass &= compare_to(B, RB);
     }
 
 
@@ -520,7 +520,7 @@ bool test_matrix_sparse_insert() {
             4,5,0,0,
             0,0,2,3,
             0,0,4,5;
-    pass &= equal_to(B, RB);
+    pass &= compare_to(B, RB);
     }
 
     {
@@ -532,7 +532,7 @@ bool test_matrix_sparse_insert() {
             0,2,3,0,
             0,4,5,0,
             0,0,0,0;
-    pass &= equal_to(B, RB);
+    pass &= compare_to(B, RB);
     }
 
     {
@@ -543,7 +543,7 @@ bool test_matrix_sparse_insert() {
             1,2,0,0,
             4,5,0,0,
             0,0,0,0;
-    pass &= equal_to(B, RB);
+    pass &= compare_to(B, RB);
     }
 
     {
@@ -554,7 +554,7 @@ bool test_matrix_sparse_insert() {
             0,3,5,0,
             0,6,0,0,
             0,0,0,0;
-    pass &= equal_to(B, RB);
+    pass &= compare_to(B, RB);
     }
 
     {
@@ -565,7 +565,7 @@ bool test_matrix_sparse_insert() {
             0,3,0,0,
             0,0,0,0,
             4,5,0,0;
-    pass &= equal_to(B, RB);
+    pass &= compare_to(B, RB);
     }
 
     {
@@ -576,7 +576,7 @@ bool test_matrix_sparse_insert() {
             0,3,0,0,
             4,5,6,7,
             8,0,0,0;
-    pass &= equal_to(B, RB);
+    pass &= compare_to(B, RB);
     }
 
     {
@@ -587,7 +587,7 @@ bool test_matrix_sparse_insert() {
             0,3,0,0,
             4,5,6,7,
             8,9,0,0;
-    pass &= equal_to(B, RB);
+    pass &= compare_to(B, RB);
     }
 
     return pass;

--- a/test/test_coordinate_matrix_inplace_merge.cpp
+++ b/test/test_coordinate_matrix_inplace_merge.cpp
@@ -78,12 +78,12 @@ BOOST_UBLAS_TEST_DEF( test_coordinate_matrix_inplace_merge_random )
 
       {
         bool sorted = check_sortedness(matrix_coord);
-        bool identical = equal_to(matrix_coord, matrix_dense, TOL);
+        bool identical = compare_to(matrix_coord, matrix_dense, TOL);
         if (!(sorted && identical)) {
           print_entries(size_x, size_y, entries);
         }
         BOOST_UBLAS_TEST_CHECK( check_sortedness(matrix_coord) );
-        BOOST_UBLAS_TEST_CHECK( equal_to(matrix_coord, matrix_dense, TOL) );
+        BOOST_UBLAS_TEST_CHECK( compare_to(matrix_coord, matrix_dense, TOL) );
       }
 
       for (size_t entry = 0; entry < nr_entries; ++ entry) {
@@ -97,7 +97,7 @@ BOOST_UBLAS_TEST_DEF( test_coordinate_matrix_inplace_merge_random )
 
       {
         bool sorted = check_sortedness(matrix_coord);
-        bool identical = equal_to(matrix_coord, matrix_dense, TOL);
+        bool identical = compare_to(matrix_coord, matrix_dense, TOL);
         if (!(sorted && identical)) {
           print_entries(size_x, size_y, entries);
         }

--- a/test/test_matrix_vector.cpp
+++ b/test/test_matrix_vector.cpp
@@ -70,7 +70,7 @@ bool test_matrix_row_facade() {
         rows(i) = matrix_row<Matrix>(RA, i);
     }
     
-    pass &= equal_to(A, RA);
+    pass &= compare_to(A, RA);
     }
 
     { // Testing operator[]
@@ -87,7 +87,7 @@ bool test_matrix_row_facade() {
         rows[i] = matrix_row<Matrix>(RA, i);
     }
     
-    pass &= equal_to(A, RA);
+    pass &= compare_to(A, RA);
     }
     
     { // Testing operator[] const
@@ -101,7 +101,7 @@ bool test_matrix_row_facade() {
             7, 8, 9;
 
     for(typename Matrix::size_type i = 0; i < RA.size1(); i++) {
-      pass &= equal_to(rows[i], matrix_row<Matrix>(RA, i));
+      pass &= compare_to(rows[i], matrix_row<Matrix>(RA, i));
     }
     }
 
@@ -119,7 +119,7 @@ bool test_matrix_row_facade() {
     for(typename RowVector::const_iterator iter = rows.begin();
 	iter != rows.end();
 	iter++) {
-      pass &= equal_to(*iter, matrix_row<Matrix>(RA, i++));
+      pass &= compare_to(*iter, matrix_row<Matrix>(RA, i++));
     }
     }
 
@@ -140,7 +140,7 @@ bool test_matrix_row_facade() {
       *iter = matrix_row<Matrix>(RA, i++);
     }
 
-    pass &= equal_to(A, RA);
+    pass &= compare_to(A, RA);
     }
 
     { // Testing reserse iterator
@@ -160,7 +160,7 @@ bool test_matrix_row_facade() {
       *iter = matrix_row<Matrix>(RA, --i);
     }
 
-    pass &= equal_to(A, RA);
+    pass &= compare_to(A, RA);
     }
 
     { // Testing const reverse iterator
@@ -177,7 +177,7 @@ bool test_matrix_row_facade() {
     for(typename RowVector::const_reverse_iterator iter = rows.rbegin();
 	iter != rows.rend();
 	iter++) {
-      pass &= equal_to(*iter, matrix_row<Matrix>(RA, --i));
+      pass &= compare_to(*iter, matrix_row<Matrix>(RA, --i));
     }
     }
 
@@ -224,7 +224,7 @@ bool test_matrix_column_facade() {
         columns(i) = matrix_column<Matrix>(RA, i);
     }
     
-    pass &= equal_to(A, RA);
+    pass &= compare_to(A, RA);
     }
 
     { // Testing operator[]
@@ -241,7 +241,7 @@ bool test_matrix_column_facade() {
         columns[i] = matrix_column<Matrix>(RA, i);
     }
     
-    pass &= equal_to(A, RA);
+    pass &= compare_to(A, RA);
     }
     
     { // Testing operator[] const
@@ -255,7 +255,7 @@ bool test_matrix_column_facade() {
             7, 8, 9;
 
     for(typename Matrix::size_type i = 0; i < RA.size2(); i++) {
-      pass &= equal_to(columns[i], matrix_column<Matrix>(RA, i));
+      pass &= compare_to(columns[i], matrix_column<Matrix>(RA, i));
     }
     }
 
@@ -276,7 +276,7 @@ bool test_matrix_column_facade() {
       *iter = matrix_column<Matrix>(RA, i++);
     }
 
-    pass &= equal_to(A, RA);
+    pass &= compare_to(A, RA);
     }
 
     { // Testing const iterator
@@ -293,7 +293,7 @@ bool test_matrix_column_facade() {
     for(typename ColumnVector::const_iterator iter = columns.begin();
 	iter != columns.end();
 	iter++) {
-      pass &= equal_to(*iter, matrix_column<Matrix>(RA, i++));
+      pass &= compare_to(*iter, matrix_column<Matrix>(RA, i++));
     }
     }
 
@@ -314,7 +314,7 @@ bool test_matrix_column_facade() {
       *iter = matrix_column<Matrix>(RA, --i);
     }
 
-    pass &= equal_to(A, RA);
+    pass &= compare_to(A, RA);
     }
 
     { // Testing const reverse iterator
@@ -331,7 +331,7 @@ bool test_matrix_column_facade() {
     for(typename ColumnVector::const_reverse_iterator iter = columns.rbegin();
 	iter != columns.rend();
 	iter++) {
-      pass &= equal_to(*iter, matrix_column<Matrix>(RA, --i));
+      pass &= compare_to(*iter, matrix_column<Matrix>(RA, --i));
     }
     }
 


### PR DESCRIPTION
... gcc-4.4.7 compiler.

Any test that was using equal_to() was failing.  Re-ran the tests and they all pass now.
