### PR TITLE
Prefix enable_if and disable_if with boost namespace.

### DIFF
--- a/include/boost/numeric/ublas/detail/returntype_deduction.hpp
+++ b/include/boost/numeric/ublas/detail/returntype_deduction.hpp
@@ -126,13 +126,13 @@ struct error_cant_deduce_type {};
     test(unsigned long const&);
 
     template <typename X, typename Y>
-    typename disable_if<
+    typename boost::disable_if<
         is_basic<X>, x_value_type
     >::type
     test(X const&);
 
     template <typename X, typename Y>
-    typename disable_if<
+    typename boost::disable_if<
         mpl::or_<
             is_basic<Y>
           , is_same<Y, asymmetric>

--- a/include/boost/numeric/ublas/matrix_expression.hpp
+++ b/include/boost/numeric/ublas/matrix_expression.hpp
@@ -3411,7 +3411,7 @@ namespace boost { namespace numeric { namespace ublas {
     // (t * m) [i] [j] = t * m [i] [j]
     template<class T1, class E2>
     BOOST_UBLAS_INLINE
-    typename enable_if< is_convertible<T1, typename E2::value_type >,
+    typename boost::enable_if< is_convertible<T1, typename E2::value_type >,
     typename matrix_binary_scalar1_traits<const T1, E2, scalar_multiplies<T1, typename E2::value_type> >::result_type
     >::type
     operator * (const T1 &e1,
@@ -3934,7 +3934,7 @@ namespace boost { namespace numeric { namespace ublas {
     // (m * t) [i] [j] = m [i] [j] * t
     template<class E1, class T2>
     BOOST_UBLAS_INLINE
-    typename enable_if< is_convertible<T2, typename E1::value_type>,
+    typename boost::enable_if< is_convertible<T2, typename E1::value_type>,
     typename matrix_binary_scalar2_traits<E1, const T2, scalar_multiplies<typename E1::value_type, T2> >::result_type
     >::type
     operator * (const matrix_expression<E1> &e1,
@@ -3946,7 +3946,7 @@ namespace boost { namespace numeric { namespace ublas {
     // (m / t) [i] [j] = m [i] [j] / t
     template<class E1, class T2>
     BOOST_UBLAS_INLINE
-    typename enable_if< is_convertible<T2, typename E1::value_type>,
+    typename boost::enable_if< is_convertible<T2, typename E1::value_type>,
     typename matrix_binary_scalar2_traits<E1, const T2, scalar_divides<typename E1::value_type, T2> >::result_type
     >::type
     operator / (const matrix_expression<E1> &e1,

--- a/include/boost/numeric/ublas/vector_expression.hpp
+++ b/include/boost/numeric/ublas/vector_expression.hpp
@@ -1235,7 +1235,7 @@ namespace boost { namespace numeric { namespace ublas {
     // (t * v) [i] = t * v [i]
     template<class T1, class E2>
     BOOST_UBLAS_INLINE
-    typename enable_if< is_convertible<T1, typename E2::value_type >,    
+    typename boost::enable_if< is_convertible<T1, typename E2::value_type >,
     typename vector_binary_scalar1_traits<const T1, E2, scalar_multiplies<T1, typename E2::value_type> >::result_type
     >::type
     operator * (const T1 &e1,
@@ -1478,7 +1478,7 @@ namespace boost { namespace numeric { namespace ublas {
     // (v * t) [i] = v [i] * t
     template<class E1, class T2>
     BOOST_UBLAS_INLINE
-    typename enable_if< is_convertible<T2, typename E1::value_type >,    
+    typename boost::enable_if< is_convertible<T2, typename E1::value_type >,
     typename vector_binary_scalar2_traits<E1, const T2, scalar_multiplies<typename E1::value_type, T2> >::result_type
     >::type
     operator * (const vector_expression<E1> &e1,
@@ -1490,7 +1490,7 @@ namespace boost { namespace numeric { namespace ublas {
     // (v / t) [i] = v [i] / t
     template<class E1, class T2>
     BOOST_UBLAS_INLINE
-    typename enable_if< is_convertible<T2, typename E1::value_type >,    
+    typename boost::enable_if< is_convertible<T2, typename E1::value_type >,
     typename vector_binary_scalar2_traits<E1, const T2, scalar_divides<typename E1::value_type, T2> >::result_type
     >::type
     operator / (const vector_expression<E1> &e1,


### PR DESCRIPTION
This is a workaround for msvc-8.0 - ambiguous symbols reported when uBlas and Boost.Test are used together.