### PR TITLE
Fix typo in fixed_matrix move assignment

### DIFF
--- a/include/boost/numeric/ublas/matrix.hpp
+++ b/include/boost/numeric/ublas/matrix.hpp
@@ -1384,7 +1384,7 @@ namespace boost { namespace numeric {
 
         /*! @note "pass by value" the key idea to enable move semantics */
         BOOST_UBLAS_INLINE
-        fixed_matrix &operator = (matrix m) {
+        fixed_matrix &operator = (fixed_matrix m) {
             assign_temporary(m);
             return *this;
         }


### PR DESCRIPTION
This is a fix for trac ticket #10762 

There was a typo in the move assignment operator, which causes any program #include-ing this file to fail if BOOST_UBLAS_MOVE_SEMANTICS is active.