### PR TITLE
Add allocator support to map_std<>

### DIFF
--- a/include/boost/numeric/ublas/storage_sparse.hpp
+++ b/include/boost/numeric/ublas/storage_sparse.hpp
@@ -195,14 +195,13 @@ namespace boost { namespace numeric { namespace ublas {
 
 
     // Default map type is simply forwarded to std::map
-    // FIXME should use ALLOC for map but std::allocator of std::pair<const I, T> and std::pair<I,T> fail to compile
     template<class I, class T, class ALLOC>
-    class map_std : public std::map<I, T /*, ALLOC */> {
+    class map_std : public std::map<I, T, std::less<I>, ALLOC> {
     public:
          // Serialization
         template<class Archive>
         void serialize(Archive & ar, const unsigned int /* file_version */){
-            ar & serialization::make_nvp("base", boost::serialization::base_object< std::map<I, T /*, ALLOC */> >(*this));
+            ar & serialization::make_nvp("base", boost::serialization::base_object< std::map<I, T, std::less<I>, ALLOC> >(*this));
         }
     };
 


### PR DESCRIPTION
There was a spurious comment

    // FIXME should use ALLOC for map but std::allocator of std::pair<const I, T> and std::pair<I,T> fail to compile

From the commented code it looked like the ALLOC had been passed as the third type argument to `std::map<>`. Obviously, that needs to be the comparator, though, so my fix was to use

    std::map<I, T, std::less<I>, ALLOC>

That compiles on all compilers I have (clang/gcc). It should compile on all standards compliant compilers/standard libraries.
