### PR TITLE
Fix bug in weak equality check

### DIFF
--- a/include/boost/numeric/ublas/detail/matrix_assign.hpp
+++ b/include/boost/numeric/ublas/detail/matrix_assign.hpp
@@ -30,7 +30,7 @@ namespace detail {
     template<class E1, class E2, class S>
     BOOST_UBLAS_INLINE
     bool equals (const matrix_expression<E1> &e1, const matrix_expression<E2> &e2, S epsilon, S min_norm) {
-        return norm_inf (e1 - e2) < epsilon *
+        return norm_inf (e1 - e2) <= epsilon *
                std::max<S> (std::max<S> (norm_inf (e1), norm_inf (e2)), min_norm);
     }
 


### PR DESCRIPTION
As mentioned in mailing list, I replace < with <=.
http://lists.boost.org/ublas/2016/03/5916.php

All tests passed except one compiler error

clang: error: unknown argument: '-fabi-version=0'

    "g++"  -ftemplate-depth-128 -O0 -fno-inline -Wall -g -dynamic -gdwarf-2 -fexceptions -fPIC -arch x86_64 -fabi-version=0 -DBOOST_ALL_NO_LIB=1 -DBOOST_UBLAS_NO_EXCEPTIONS -DEXTERNAL  -I"../../../.." -c -o "../../../../bin.v2/libs/numeric/ublas/test/concepts.test/darwin-4.2.1/debug/concepts.o" "concepts.cpp"