### PR TITLE
Fix compilation error when BOOST_UBLAS_SCALED_NORM is defined

### DIFF
--- a/include/boost/numeric/ublas/functional.hpp
+++ b/include/boost/numeric/ublas/functional.hpp
@@ -433,10 +433,10 @@ namespace boost { namespace numeric { namespace ublas {
         template<class E>
         static BOOST_UBLAS_INLINE
         result_type apply (const vector_expression<E> &e) {
-#ifndef BOOST_UBLAS_SCALED_NORM
-            real_type t = real_type ();
             typedef typename E::size_type vector_size_type;
             vector_size_type size (e ().size ());
+#ifndef BOOST_UBLAS_SCALED_NORM
+            real_type t = real_type ();
             for (vector_size_type i = 0; i < size; ++ i) {
                 real_type u (type_traits<value_type>::norm_2 (e () (i)));
                 t +=  u * u;
@@ -445,8 +445,7 @@ namespace boost { namespace numeric { namespace ublas {
 #else
             real_type scale = real_type ();
             real_type sum_squares (1);
-            size_type size (e ().size ());
-            for (size_type i = 0; i < size; ++ i) {
+            for (vector_size_type i = 0; i < size; ++ i) {
                 real_type u (type_traits<value_type>::norm_2 (e () (i)));
                 if ( real_type () /* zero */ == u ) continue;
                 if (scale < u) {

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -189,6 +189,10 @@ test-suite numeric/uBLAS
       ]
       [ run test_complex_norms.cpp
       ]
+      [ run test_scaled_norm.cpp
+       : : :
+           <define>BOOST_UBLAS_SCALED_NORM
+      ]
       [ run test_assignment.cpp
        : : :
            <define>BOOST_UBLAS_COO_ALWAYS_DO_FULL_SORT

--- a/test/test_scaled_norm.cpp
+++ b/test/test_scaled_norm.cpp
@@ -1,0 +1,41 @@
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include <boost/numeric/ublas/vector.hpp>
+#include <boost/numeric/ublas/io.hpp>
+
+#include "utils.hpp"
+
+using namespace boost::numeric::ublas;
+
+static const double TOL(1.0e-5); ///< Used for comparing two real numbers.
+
+BOOST_UBLAS_TEST_DEF ( test_double_scaled_norm_2 ) {
+    vector<double> v(2);
+    v[0] = 0; v[1] = 1.0e155;
+
+    const double expected = 1.0e155;
+
+    BOOST_UBLAS_DEBUG_TRACE( "norm is " << norm_2(v) );
+    BOOST_UBLAS_TEST_CHECK(std::abs(norm_2(v) - expected) < TOL);
+}
+
+BOOST_UBLAS_TEST_DEF ( test_float_scaled_norm_2 ) {
+    vector<float> v(2);
+    v[0] = 0; v[1] = 1.0e20;
+
+    const float expected = 1.0e20;
+
+    BOOST_UBLAS_DEBUG_TRACE( "norm is " << norm_2(v) );
+    BOOST_UBLAS_TEST_CHECK(std::abs(norm_2(v) - expected) < TOL);
+}
+
+int main() {
+    BOOST_UBLAS_TEST_BEGIN();
+
+    BOOST_UBLAS_TEST_DO( test_double_scaled_norm_2 );
+    BOOST_UBLAS_TEST_DO( test_float_scaled_norm_2 );
+
+    BOOST_UBLAS_TEST_END();
+}


### PR DESCRIPTION
Commit e6b113 changed the `size_type` typedef to be based on the
container and in doing so missed the case in vector_norm_2 when
BOOST_UBLAS_SCALED_NORM is define. Also added test cases.