### PR TITLE
Misplaced brace in matrix_expression.hpp

### DIFF
--- a/include/boost/numeric/ublas/matrix_expression.hpp
+++ b/include/boost/numeric/ublas/matrix_expression.hpp
@@ -2221,10 +2221,10 @@ namespace boost { namespace numeric { namespace ublas {
                         index1 = it1_.index1 ();
                 }
                 size_type index2 = (*this) ().size1 ();
-                if (it2_ != it2_end_)
+                if (it2_ != it2_end_) {
                     if (it2_.index1 () <= i_)
                         ++ it2_;
-                    if (it2_ != it2_end_) {
+                    if (it2_ != it2_end_) 
                         index2 = it2_.index1 ();
                 }
                 i_ = (std::min) (index1, index2);


### PR DESCRIPTION
For sparse iterators, there is a misplaced brace that causes compilation errors with more recent versions of gcc. This was correctly placed in 1.57, but a git blame shows this somehow got reverted to a 2002 commit. So I put it back.